### PR TITLE
BAU Simplify install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pay-dependabot-stats
 A dashboard that shows stats regarding the current dependabot PRs for GOV.UK Pay
 ## How to run
-Create a github OAuth key, and place it in a file named Secret.ts like so:
+Create a github OAuth key, and place it in a file named `src/Secret.ts` like so:
 
 ```
 const apiKey: string = "YOUR_GITHUB_OAUTH_KEY";

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/react-dom": "16.9.1",
     "concurrently": "^4.1.2",
     "electron-is-dev": "^1.1.0",
+    "govuk-frontend": "^3.2.0",
     "lint-staged": "^9.4.0",
     "moment": "^2.24.0",
     "mrm": "^1.2.2",
@@ -25,14 +26,14 @@
     "eject": "react-scripts eject",
     "electron-dev": "concurrently \"BROWSER=none yarn start\" \"wait-on http://localhost:3000 && electron .\"",
     "pack": "electron-builder --dir",
-    "dist": "electron-builder"  
+    "dist": "electron-builder"
   },
   "build": {
     "appId": "pay.dependabot.stats",
     "mac": {
       "category": "internal.tool"
     }
-  },  
+  },
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,6 @@
 @font-face {
   font-family: 'GDS Transport';
-  src: local('GDS Transport'), url(./fonts/bold-affa96571d-v2.woff) format('woff');
+  src: local('GDS Transport'), url(./../node_modules/govuk-frontend/govuk/assets/fonts/bold-affa96571d-v2.woff) format('woff');
 }
 
 .App {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5005,6 +5005,11 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
+govuk-frontend@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.2.0.tgz#0f935bee092929455bf7ed08bba40ab07ea72769"
+  integrity sha512-OtJozAGMEKFu195fNVVrQHUX7+znCkA4cXDKs4lgFlRQOTzN1ogT9010GBARuoTwbeL0VqQ8nerZYjVxH/wafA==
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"


### PR DESCRIPTION
This commit simplifies the install process for new contributors.
* Update README to explicitly name `src/Secret.ts` file location
* Add `govuk-frontend` as a dependency and update CSS to point at the
distribution folder. Contributors will not need to manually download and
correctly place the `fonts` folder.